### PR TITLE
bugfix: docker compose postgres restart

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
     postgres:
         image: postgres:14.2-alpine
+        restart: unless-stopped
         environment:
             - POSTGRES_PASSWORD=supersecurepassword
             - PGDATA=/var/lib/postgresql/data/pgdata


### PR DESCRIPTION
Added the restart unless stopped flag to the postgres service in docker compose, sometimes postgres crashes wich causes boolean to stop working in production.